### PR TITLE
Update GitHub Actions tags to digests

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -21,5 +21,5 @@ permissions: {}
 
 jobs:
   terraform-module:
-    uses: cloudposse/.github/.github/workflows/shared-terraform-module.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-terraform-module.yml@289afbc41bbefd9a76f18024edc879e38145f1b4 # main
     secrets: inherit

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/.github/.github/workflows/shared-terraform-chatops.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-terraform-chatops.yml@289afbc41bbefd9a76f18024edc879e38145f1b4 # main
     secrets:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/.github/.github/workflows/shared-release-branches.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-release-branches.yml@289afbc41bbefd9a76f18024edc879e38145f1b4 # main
     secrets: inherit

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   scheduled:
-    uses: cloudposse/.github/.github/workflows/shared-terraform-scheduled.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-terraform-scheduled.yml@289afbc41bbefd9a76f18024edc879e38145f1b4 # main
     secrets: inherit


### PR DESCRIPTION
This PR changes the projects GitHub Actions tags to digests.  

For more details on why this is useful, refer to the [GitHubs own documentation on security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

To automate this process, you could also use [Minder](https://cloud.stacklok.com),
the open-source DevSecOps platform. Stacklok offers a free-for-open-source hosted version.

Full disclosure: I am an open source dev working at Stacklok on the Minder
Open source project, aiming to help secure the open source software.
